### PR TITLE
Fix Windows build errors & warning

### DIFF
--- a/src/Philodendron.h
+++ b/src/Philodendron.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include <mutex>
 #include <vector>
 
 // #include "Filter.hpp"

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -40,16 +40,16 @@ namespace buffer{
 			int_read = 0;
 		if (int_read > m_buffer_size -2)
 			int_read = m_buffer_size - 2;
-			// get previous sample
-			float sample1 = m_buffer[int_read];
-			// get next sample
-			float sample2 = m_buffer[int_read + 1];
-			// linear interpolation
-			float output = ((sample2 - sample1) * fractional) + sample1;
-			// workaround for the bug
-			if (output > 10. || output < -10.)
-			{
-				clearBuffer();
+        // get previous sample
+        float sample1 = m_buffer[int_read];
+        // get next sample
+        float sample2 = m_buffer[int_read + 1];
+        // linear interpolation
+        float output = ((sample2 - sample1) * fractional) + sample1;
+        // workaround for the bug
+        if (output > 10. || output < -10.)
+        {
+            clearBuffer();
 		}
 		return output;
 	}


### PR DESCRIPTION
```
src/buffer.cpp: In member function 'float noi::buffer::RingBuffer::read()':                                             
src/buffer.cpp:41:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]                            
   41 |                 if (int_read > m_buffer_size -2)                                                                
      |                 ^~                                                                                              
src/buffer.cpp:44:25: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
   44 |                         float sample1 = m_buffer[int_read];                                                     
      |                         ^~~~~                                                                                   

In file included from src/Philodendron.cpp:11:
src/Philodendron.h:38:8: error: 'mutex' in namespace 'std' does not name a type
   38 |   std::mutex mutex;
      |        ^~~~~
src/Philodendron.h:18:1: note: 'std::mutex' is defined in header '<mutex>'; this is probably fixable by adding '#include <mutex>'
   17 | #include "RingBuffer.hpp"
  +++ |+#include <mutex>
   18 | namespace noi {
src/Philodendron.h:115:8: error: 'shared_ptr' in namespace 'std' does not name a template type
  115 |   std::shared_ptr<ExchangeBuffer> exchange_buffer;
      |        ^~~~~~~~~~
src/Philodendron.h:18:1: note: 'std::shared_ptr' is defined in header '<memory>'; this is probably fixable by adding '#include <memory>'
   17 | #include "RingBuffer.hpp"
  +++ |+#include <memory>
   18 | namespace noi {
```
